### PR TITLE
Add UPSERT to handle late observations

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,12 @@ PiWS services.
 * Git
 * Arudino Temperature Control Library (Dallas Temperature)
 * DHT library
+* PostgreSQL 9.5 +
 
+### Will you support older version of PostgreSQL than 9.5?
+
+No.  The data loading code uses `ON CONFLICT` and requires PostgreSQL 9.5 or
+later.
 
 ## Setting Up
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,16 @@ To run the PiWS, setup connection to database using environment variables.
 ```bash
 source ~/venv/piws/bin/activate
 
+cd ~/git/piws
+
 export DB_HOST=127.0.0.1
 export DB_USER=piws
 export DB_NAME=piws
 export DB_PW=SecurePassword
+export APP_LOG_LEVEL=DEBUG
 
 python run_station.py
+
 ```
 
 ```bash

--- a/db/deploy/006.sql
+++ b/db/deploy/006.sql
@@ -1,0 +1,107 @@
+-- Deploy piws:006 to pg
+
+BEGIN;
+
+    -- Recreating the index with much better name.
+    ALTER TABLE piws.observation_minute DROP CONSTRAINT uq_observation_minute_;
+
+    ALTER TABLE piws.observation_minute
+        ADD CONSTRAINT uq_observation_minute_datetime_sensor
+        UNIQUE (sensor_id, calendar_id, time_id, sensor_name);
+
+
+
+    CREATE OR REPLACE FUNCTION piws.load_minute_observations()
+     RETURNS boolean
+     LANGUAGE sql
+     SECURITY DEFINER
+     SET search_path TO "piws, pg_temp"
+    AS $function$
+
+
+                WITH obs AS (
+                    SELECT o.observation_id
+                        FROM piws.observation o
+                        INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                        INNER JOIN public.time t ON o.time_id = t.time_id
+                        WHERE imported = False
+                            -- Either older than today...
+                            AND (c.datum != (NOW() AT TIME ZONE o.timezone)::DATE
+                                OR ( -- or today, but not *this* minute
+                                    c.datum = (NOW() AT TIME ZONE o.timezone)::DATE
+                                        AND to_char(t.timeofday  + '2 minutes'::interval, 'HH24:MI') < to_char(NOW() AT TIME ZONE o.timezone, 'HH24:MI')
+                                )
+                            )
+                ), obs_detail AS (
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'dht11_h' AS sensor_name,
+                            (o.sensor_values ->> 'dht11_h')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                    UNION
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'dht11_t' AS sensor_name,
+                            (sensor_values ->> 'dht11_t')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                    UNION
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'ds18b20_t' AS sensor_name,
+                            (o.sensor_values ->> 'ds18b20_t')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                            AND (o.sensor_values ->> 'ds18b20_t')::NUMERIC != -127 -- Known bad sensor readings
+                ), minute_aggs AS (
+                SELECT o.sensor_id, o.calendar_id,
+                        to_char(t.timeofday, 'HH24:MI') AS hhmm,
+                        o.timezone,
+                        o.sensor_name,
+                        ROUND(AVG(o.sensor_value), 2) AS sensor_value
+                    FROM obs_detail o
+                    INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                    INNER JOIN public.time t ON o.time_id = t.time_id
+                   GROUP BY o.sensor_id, o.calendar_id,
+                        to_char(t.timeofday, 'HH24:MI'),
+                        o.timezone,
+                        o.sensor_name
+                )
+                INSERT INTO piws.observation_minute (sensor_id, calendar_id, time_id, timezone, sensor_name, sensor_value)
+                SELECT a.sensor_id, a.calendar_id, t.time_id, a.timezone, a.sensor_name, a.sensor_value
+                    FROM minute_aggs a
+                    INNER JOIN public.time t ON a.hhmm = to_char(t.timeofday, 'HH24:MI') AND t.second = 0
+                ON CONFLICT (sensor_id, calendar_id, time_id, sensor_name)
+                    DO
+                    UPDATE
+                        SET sensor_value = EXCLUDED.sensor_value
+                ;
+
+
+                -----------------------------------------
+                -----------------------------------------
+                -----------------------------------------
+
+            WITH minute_obs AS (
+                SELECT DISTINCT m.sensor_id, c.calendar_id, to_char(t.timeofday, 'HH24:MI') AS hhmm, t.hour, t.minute
+                    FROM piws.observation_minute m
+                    INNER JOIN public.time t ON m.time_id = t.time_id
+                    INNER JOIN public.calendar c ON m.calendar_id = c.calendar_id
+            ), not_imported AS (
+                -- NOW to convert this to a format matching the above
+                SELECT o.observation_id, c.calendar_id, to_char(t.timeofday, 'HH24:MI') AS hhmm, t.hour, t.minute
+                    FROM piws.observation o
+                    INNER JOIN public.time t ON o.time_id = t.time_id
+                    INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                    WHERE imported = False
+            )
+            UPDATE piws.observation AS o
+                SET imported = True
+                FROM  not_imported n
+                INNER JOIN minute_obs m ON m.calendar_id = n.calendar_id AND m.hhmm = n.hhmm
+                WHERE o.observation_id = n.observation_id
+                ;
+
+
+            SELECT True;
+            $function$;
+
+COMMIT;

--- a/db/revert/006.sql
+++ b/db/revert/006.sql
@@ -1,0 +1,105 @@
+-- Revert piws:006 from pg
+
+BEGIN;
+
+    -- Put the bad name back...
+    ALTER TABLE piws.observation_minute DROP CONSTRAINT uq_observation_minute_datetime_sensor;
+
+    ALTER TABLE piws.observation_minute
+        ADD CONSTRAINT  uq_observation_minute_
+        UNIQUE (sensor_id, calendar_id, time_id, sensor_name);
+
+
+
+    CREATE OR REPLACE FUNCTION piws.load_minute_observations()
+     RETURNS boolean
+     LANGUAGE sql
+     SECURITY DEFINER
+     SET search_path TO "piws, pg_temp"
+    AS $function$
+
+
+                WITH obs AS (
+                    SELECT o.observation_id
+                        FROM piws.observation o
+                        INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                        INNER JOIN public.time t ON o.time_id = t.time_id
+                        WHERE imported = False
+                            -- Either older than today...
+                            AND (c.datum != (NOW() AT TIME ZONE o.timezone)::DATE
+                                OR ( -- or today, but not *this* minute
+                                    c.datum = (NOW() AT TIME ZONE o.timezone)::DATE
+                                        AND to_char(t.timeofday  + '2 minutes'::interval, 'HH24:MI') < to_char(NOW() AT TIME ZONE o.timezone, 'HH24:MI')
+                                )
+                            )
+                ), obs_detail AS (
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'dht11_h' AS sensor_name,
+                            (o.sensor_values ->> 'dht11_h')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                    UNION
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'dht11_t' AS sensor_name,
+                            (sensor_values ->> 'dht11_t')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                    UNION
+                    SELECT o.sensor_id, o.calendar_id, o.time_id, o.timezone,
+                            'ds18b20_t' AS sensor_name,
+                            (o.sensor_values ->> 'ds18b20_t')::NUMERIC AS sensor_value
+                        FROM obs a
+                        INNER JOIN piws.observation o ON a.observation_id = o.observation_id
+                            AND (o.sensor_values ->> 'ds18b20_t')::NUMERIC != -127 -- Known bad sensor readings
+                ), minute_aggs AS (
+                SELECT o.sensor_id, o.calendar_id,
+                        to_char(t.timeofday, 'HH24:MI') AS hhmm,
+                        o.timezone,
+                        o.sensor_name,
+                        ROUND(AVG(o.sensor_value), 2) AS sensor_value
+                    FROM obs_detail o
+                    INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                    INNER JOIN public.time t ON o.time_id = t.time_id
+                   GROUP BY o.sensor_id, o.calendar_id,
+                        to_char(t.timeofday, 'HH24:MI'),
+                        o.timezone,
+                        o.sensor_name
+                )
+                INSERT INTO piws.observation_minute (sensor_id, calendar_id, time_id, timezone, sensor_name, sensor_value)
+                SELECT a.sensor_id, a.calendar_id, t.time_id, a.timezone, a.sensor_name, a.sensor_value
+                    FROM minute_aggs a
+                    INNER JOIN public.time t ON a.hhmm = to_char(t.timeofday, 'HH24:MI') AND t.second = 0
+
+                ;
+
+
+                -----------------------------------------
+                -----------------------------------------
+                -----------------------------------------
+
+            WITH minute_obs AS (
+                SELECT DISTINCT m.sensor_id, c.calendar_id, to_char(t.timeofday, 'HH24:MI') AS hhmm, t.hour, t.minute
+                    FROM piws.observation_minute m
+                    INNER JOIN public.time t ON m.time_id = t.time_id
+                    INNER JOIN public.calendar c ON m.calendar_id = c.calendar_id
+            ), not_imported AS (
+                -- NOW to convert this to a format matching the above
+                SELECT o.observation_id, c.calendar_id, to_char(t.timeofday, 'HH24:MI') AS hhmm, t.hour, t.minute
+                    FROM piws.observation o
+                    INNER JOIN public.time t ON o.time_id = t.time_id
+                    INNER JOIN public.calendar c ON o.calendar_id = c.calendar_id
+                    WHERE imported = False
+            )
+            UPDATE piws.observation AS o
+                SET imported = True
+                FROM  not_imported n
+                INNER JOIN minute_obs m ON m.calendar_id = n.calendar_id AND m.hhmm = n.hhmm
+                WHERE o.observation_id = n.observation_id
+                ;
+
+
+            SELECT True;
+            $function$;
+
+
+COMMIT;

--- a/db/sqitch.plan
+++ b/db/sqitch.plan
@@ -7,3 +7,4 @@
 003 [002] 2018-03-04T16:21:50Z Ryan Lambert <ryanlambert@rustprooflabs.com> # Updating views for sending to API
 004 [003] 2018-03-06T00:56:46Z Ryan Lambert <ryanlambert@rustprooflabs.com> # Tracking submitted quarterhour API submissions
 005 [004] 2018-04-18T16:58:38Z ryanlambert <ryan@rustprooflabs.com> # Improve data structure and retention
+006 [005] 2018-04-27T12:56:55Z Ryan Lambert <ryan@rustprooflabs.com> # Improving loading of minute-level data to avoid UQ violations

--- a/db/verify/006.sql
+++ b/db/verify/006.sql
@@ -1,0 +1,7 @@
+-- Verify piws:006 on pg
+
+BEGIN;
+
+-- XXX Add verifications here.
+
+ROLLBACK;


### PR DESCRIPTION
Note:  This change introduces an minimum supported  version of PostgreSQL 9.5.  Updated README accordingly.